### PR TITLE
fix: wrap audiocontext creation in a singleton

### DIFF
--- a/src/sampler.js
+++ b/src/sampler.js
@@ -1,5 +1,14 @@
+function getAudioContext() {
+  if (!getAudioContext.instance) {
+    getAudioContext.instance = new (window.AudioContext || window.webkitAudioContext)();
+  }
+
+  return getAudioContext.instance;
+}
+
+
 export const play = (sound) => {
-  var audio = new (window.AudioContext || window.webkitAudioContext)();
+  var audio = getAudioContext();
 
   let data = audio.createBuffer(2, sound.dataLength / 2 * 8 / sound.bitsPerSample, sound.sampleRate);
 


### PR DESCRIPTION
The number of AudioContexts is limited to 6 on Chrome which makes play() stop working after this number is reached. Only one AudioContext is necessary to the whole application. The AudioContext can be wrapped in a singleton to ensure only one will be used.